### PR TITLE
Remove interareal module

### DIFF
--- a/Python/Mejias-2016.py
+++ b/Python/Mejias-2016.py
@@ -13,7 +13,6 @@ from intralaminar import intralaminar_simulation, intralaminar_analysis, intrala
 from interlaminar import interlaminar_simulation, interlaminar_activity_analysis, plot_activity_traces, \
                          calculate_interlaminar_power_spectrum, \
                          plot_interlaminar_power_spectrum
-from interareal import interareal_simulation
 from helper_functions import firing_rate_analysis
 
 """


### PR DESCRIPTION
Fix issue https://github.com/OpenSourceBrain/MejiasEtAl2016/issues/5

As the interareal simulation is still work in progress, I removed it completely from the main Mejias-2016 script, for now.
