### PR TITLE
Interareal analysis using the NeuroMLlite simulation.

### DIFF
--- a/NeuroML2/GenerateNeuroMLlite.py
+++ b/NeuroML2/GenerateNeuroMLlite.py
@@ -700,13 +700,14 @@ if __name__ == "__main__":
         dt = 2e-01
         transient = 5
         duration = 4e04
-        minfreq_l23 = 30 # Hz
-        minfreq_l56 = 3 # Hz
+        minfreq_l23 = 30. # Hz
+        minfreq_l56 = 3. # Hz
         areas = ['V1', 'V4']
+        nareas = len(areas)
 
         # for testing purpose generate one single simulation
         if '-analysis' in sys.argv:
-            stats = 3
+            stats = 10
         else:
             stats = 1
 
@@ -715,7 +716,7 @@ if __name__ == "__main__":
             # Iext1: Excitatory current on layer E l56
             # The first 2 values correspond to the first area, the last 2 values for the second area
             stimulated_area = 'stimulate_V1'
-            Iext0 = 2; Iext1= 4 # background current at excitatory population
+            Iext0 = 2; Iext1 = 4 # background current at excitatory population
             Iext_rest = [[Iext0, Iext1],[Iext0, Iext1]]
             # Injection is applied at V1
             stim = 15
@@ -770,7 +771,6 @@ if __name__ == "__main__":
 
         if '-analysis' in sys.argv:
 
-            n_areas = 2
             # Concatenate the simulation results in the same format as the matlab code
             # No stimulus
             rate_rest_all = np.zeros((len(traces_rest_stats[0]) - 1, len(traces_rest_stats[0]['V1_L23_E/0/L23_E_comp/r']), stats))
@@ -797,11 +797,11 @@ if __name__ == "__main__":
             # TODO: Make this more obvious
 
             # Perfrom analysis with both rest and stimulated simulation
-            px20, px2, px50, px5, fx2 = interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq_l23, minfreq_l56,
-                                                            n_areas, stats)
+            px20, px2, px50, px5, fx2, pgamma, palpha = interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq_l23, minfreq_l56,
+                                                            nareas, stats)
 
             # Plot the results
-            interareal_plt(areas, px20, px2, px50, px5, fx2, stimulated_area)
+            interareal_plt(areas, px20, px2, px50, px5, fx2, stimulated_area, stats)
 
         print('Done')
 

--- a/NeuroML2/GenerateNeuroMLlite.py
+++ b/NeuroML2/GenerateNeuroMLlite.py
@@ -10,7 +10,7 @@ sys.path.append("../Python")
 def generate(wee = 1.5, wei = -3.25, wie = 3.5, wii = -2.5,
              i_l5e_l2i=0., i_l2e_l5e=0.,
              areas=['V1'], FF_l2e_l2e=0., FB_l5e_l2i=0., FB_l5e_l5e=0., FB_l5e_l5i=0., FB_l5e_l2e=0.,
-             sigma23=.3, sigma56=.45, noise=True, duration=1000, dt=0.2, Iext=[0, 0], count=0,
+             sigma23=.3, sigma56=.45, noise=True, duration=1000, dt=0.2, Iext=[[0, 0]], count=0,
              net_id='MejiasFig2'):
 
     ################################################################################
@@ -55,15 +55,17 @@ def generate(wee = 1.5, wei = -3.25, wie = 3.5, wii = -2.5,
     net.cells.append(l56icell)
 
     # Background input
-    input_source_l23 = InputSource(id='iclamp_23',
-                                   neuroml2_input='PulseGenerator',
-                                   parameters={'amplitude':'%snA'%Iext[0], 'delay':'0ms', 'duration':'%sms'%duration})
-    net.input_sources.append(input_source_l23)
-    input_source_l56 = InputSource(id='iclamp_56',
-                                   neuroml2_input='PulseGenerator',
-                                   parameters={'amplitude':'%snA'%Iext[1], 'delay':'0ms', 'duration':'%sms'%duration})
+    # Iterate over the different possible areas
+    for area_idx, area in enumerate(areas):
+        input_source_l23 = InputSource(id='iclamp_23_%s' %area,
+                                       neuroml2_input='PulseGenerator',
+                                       parameters={'amplitude':'%snA'%Iext[area_idx][0], 'delay':'0ms', 'duration':'%sms'%duration})
+        net.input_sources.append(input_source_l23)
+        input_source_l56 = InputSource(id='iclamp_56_%s' %area,
+                                       neuroml2_input='PulseGenerator',
+                                       parameters={'amplitude':'%snA'%Iext[area_idx][1], 'delay':'0ms', 'duration':'%sms'%duration})
 
-    net.input_sources.append(input_source_l56)
+        net.input_sources.append(input_source_l56)
 
 
     color_str = {'l23e':'.8 0 0','l23i':'0 0 .8',
@@ -276,7 +278,7 @@ if __name__ == "__main__":
                         pop_color = pop_colors[pop_type]
                         colors.append(pop_color)
 
-                        hist1, edges1 = np.histogram(traces[tr],bins=hist_bins)
+                        hist1, edges1 = np.histogram(traces[tr], bins=hist_bins)
                         mid1 = [e +(edges1[1]-edges1[0])/2 for e in edges1[:-1]]
                         histxs.append(mid1)
                         histys.append(hist1)
@@ -310,7 +312,7 @@ if __name__ == "__main__":
                     labels.append(pop)
                     colors.append(pop_colors[pop])
 
-                    hist1, edges1 = np.histogram(l23e,bins=hist_bins)
+                    hist1, edges1 = np.histogram(l23e, bins=hist_bins)
                     mid1 = [e +(edges1[1]-edges1[0])/2 for e in edges1[:-1]]
                     histxs.append(mid1)
                     histys.append(hist1)
@@ -324,7 +326,7 @@ if __name__ == "__main__":
                     labels.append(pop)
                     colors.append(pop_colors[pop])
 
-                    hist1, edges1 = np.histogram(l23i,bins=hist_bins)
+                    hist1, edges1 = np.histogram(l23i, bins=hist_bins)
                     mid1 = [e +(edges1[1]-edges1[0])/2 for e in edges1[:-1]]
                     histxs.append(mid1)
                     histys.append(hist1)
@@ -338,7 +340,7 @@ if __name__ == "__main__":
                     labels.append(pop)
                     colors.append(pop_colors[pop])
 
-                    hist1, edges1 = np.histogram(l56e,bins=hist_bins)
+                    hist1, edges1 = np.histogram(l56e, bins=hist_bins)
                     mid1 = [e +(edges1[1]-edges1[0])/2 for e in edges1[:-1]]
                     histxs.append(mid1)
                     histys.append(hist1)
@@ -351,7 +353,7 @@ if __name__ == "__main__":
                     labels.append(pop)
                     colors.append(pop_colors[pop])
 
-                    hist1, edges1 = np.histogram(l56i,bins=hist_bins)
+                    hist1, edges1 = np.histogram(l56i, bins=hist_bins)
                     mid1 = [e +(edges1[1]-edges1[0])/2 for e in edges1[:-1]]
                     histxs.append(mid1)
                     histys.append(hist1)
@@ -412,7 +414,7 @@ if __name__ == "__main__":
             simulation[Iext] = {}
             for run in range(nruns):
                 sim, net = generate(wee=wee, wei=wei, wie=wie, wii=wii, i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e, duration=25000,
-                                    areas=['V1'], Iext=[Iext, Iext], count=run,
+                                    areas=['V1'], Iext=[[Iext, Iext]], count=run,
                                     net_id='Intralaminar')
                                     
                 ################################################################################
@@ -464,7 +466,7 @@ if __name__ == "__main__":
 
         wee = JEE; wei = JIE; wie = JEI; wii = JII; l5e_l2i = .75; l2e_l5e = 1
         sim, net = generate(wee=wee, wei=wei, wie=wie, wii=wii, i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e, dt=dt,
-                            areas=['V1'], duration=duration, Iext=[8, 8], count=0,
+                            areas=['V1'], duration=duration, Iext=[[8, 8]], count=0,
                             net_id='Interlaminar')
         # Run in some simulators
         check_to_generate_or_run(sys.argv, sim)
@@ -577,7 +579,7 @@ if __name__ == "__main__":
             # Repeat the calculations for the case where there is no connection between layers
             wee = JEE; wei = JIE; wie = JEI; wii = JII; l5e_l2i = 0; l2e_l5e = 0
             sim, net = generate(wee=wee, wei=wei, wie=wie, wii=wii, i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e, duration=duration,
-                                areas=['V1'], Iext=[8, 8], count=0)
+                                areas=['V1'], Iext=[[8, 8]], count=0)
             # Run in some simulators
             check_to_generate_or_run(sys.argv, sim)
             simulator = 'jNeuroML'
@@ -689,7 +691,9 @@ if __name__ == "__main__":
     elif '-interareal' in sys.argv:
         from interareal import interareal_analysis
 
-        # Background current simulation
+        # Background current simulation.
+        # Note: For testing porpose, only the rest simulation is performed if the flag '-analysis' is not
+        # passed
         wee = JEE; wei = JIE; wie = JEI; wii = JII; l5e_l2i = .75; l2e_l5e = 1
         FF_l2e_l2e = 1; FB_l5e_l2i = .5; FB_l5e_l5e=.9; FB_l5e_l5i = .5; FB_l5e_l2e = .1
         dt = 2e-01
@@ -698,46 +702,93 @@ if __name__ == "__main__":
         minfreq = 30 # Hz
         Iext0 = 2; Iext1= 4 # external injected current
 
-        sim, net = generate(wee=wee, wei=wei, wie=wie, wii=wii,
-                            i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e,
-                            areas=['V1', 'V4'], FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
-                            FB_l5e_l5i=FB_l5e_l5i, FB_l5e_l2e=FB_l5e_l2e,
-                            dt=dt, duration=duration, Iext=[Iext0, Iext1])
-        # Run in some simulators
-        check_to_generate_or_run(sys.argv, sim)
-        simulator = 'jNeuroML'
+        # for testing purpose generate one single simulation
+        if '-analysis' in sys.argv:
+            stats = 5
+        else:
+            stats = 1
 
-        nmllr = NeuroMLliteRunner('%s.json' %sim.id,
-                                    simulator=simulator)
-        traces, events = nmllr.run_once('/tmp')
-        rate_conn = np.array([])
+        traces_rest_stats = []
+        traces_stim_stats = []
+        for stat in range(stats):
+            # Run simulation at rest
+            sim_rest, net_rest = generate(wee=wee, wei=wei, wie=wie, wii=wii,
+                                          i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e,
+                                          areas=['V1', 'V4'], FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
+                                          FB_l5e_l5i=FB_l5e_l5i, FB_l5e_l2e=FB_l5e_l2e,
+                                          dt=dt, duration=duration, Iext=[[Iext0, Iext1],[Iext0, Iext1]])
+            # Run in some simulators
+            check_to_generate_or_run(sys.argv, sim_rest)
+            simulator = 'jNeuroML'
+
+            nmllr = NeuroMLliteRunner('%s.json' %sim_rest.id,
+                                        simulator=simulator)
+            traces_rest, events_rest = nmllr.run_once('/tmp')
+            traces_rest_stats.append(traces_rest)
+
+            # Run simulation with microsimulation
+            # Injection is applied at V1
+            Iext_stim = 15
+            sim_stim, net_stim = generate(wee=wee, wei=wei, wie=wie, wii=wii,
+                                          i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e,
+                                          areas=['V1', 'V4'], FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
+                                          FB_l5e_l5i=FB_l5e_l5i, FB_l5e_l2e=FB_l5e_l2e,
+                                          dt=dt, duration=duration, Iext=[[Iext_stim + Iext0, Iext_stim + Iext1], [Iext0, Iext1]])
+            # Run in some simulators
+            check_to_generate_or_run(sys.argv, sim_rest)
+            simulator = 'jNeuroML'
+
+            nmllr = NeuroMLliteRunner('%s.json' %sim_rest.id,
+                                      simulator=simulator)
+            traces_stim, events_stim = nmllr.run_once('/tmp')
+            traces_stim_stats.append(traces_rest)
+
 
         if '-analysis' in sys.argv:
 
             n_areas = 2
-            stats = 2
+            # No stimulus
+            rate_rest_all = np.zeros((len(traces_rest_stats[1]) - 1, len(traces_rest_stats[1]['V1_L23_E/0/L23_E_comp/r']), stats))
+            for stat in range(stats):
+                for idx, key in enumerate(sorted(traces_rest_stats[stat].keys())):
+                    if key is not 't':
+                        rate_rest_all[idx, :, stat] = traces_rest_stats[stat][key]
+            # With stimulus
+            rate_stim_all = np.zeros((len(traces_rest_stats[1]) - 1, len(traces_rest_stats[1]['V1_L23_E/0/L23_E_comp/r']), stats))
+            for stat in range(stats):
+                for idx, key in enumerate(sorted(traces_stim_stats[stat].keys())):
+                    if key is not 't':
+                        rate_stim_all[idx, :, stat] = traces_stim_stats[stat][key]
+
+            # TODO: Make this more obvious
+            # for compatibility with the Python code, expand the third dimension
+            rate_rest = np.expand_dims(rate_rest_all, axis=2)
+            # transform the dt from ms to s, for the rest of the analysis
+            s_dt = dt / 1000
+            # perform simulation with background current
+
             # TODO: Improve the generalisation of the code
             # for key in traces.keys():
             #     if key is not 't':
             #         curr_array = np.array(traces[key])
             #         rate_conn = np.stack([rate_conn, curr_array], axis=0)
-            rate_conn = np.stack((np.array(traces['V1_L23_E/0/L23_E_comp/r']),
-                                  np.array(traces['V1_L23_I/0/L23_I_comp/r']),
-                                  np.array(traces['V1_L56_E/0/L56_E_comp/r']),
-                                  np.array(traces['V1_L56_I/0/L56_I_comp/r']),
-                                  np.array(traces['V4_L23_E/0/L23_E_comp/r']),
-                                  np.array(traces['V4_L23_I/0/L23_I_comp/r']),
-                                  np.array(traces['V4_L56_E/0/L56_E_comp/r']),
-                                  np.array(traces['V4_L56_I/0/L56_I_comp/r']),
+            rate_stim = np.array([])
+            rate_stim = np.stack((np.array(traces_stim['V1_L23_E/0/L23_E_comp/r']),
+                                  np.array(traces_stim['V1_L23_I/0/L23_I_comp/r']),
+                                  np.array(traces_stim['V1_L56_E/0/L56_E_comp/r']),
+                                  np.array(traces_stim['V1_L56_I/0/L56_I_comp/r']),
+                                  np.array(traces_stim['V4_L23_E/0/L23_E_comp/r']),
+                                  np.array(traces_stim['V4_L23_I/0/L23_I_comp/r']),
+                                  np.array(traces_stim['V4_L56_E/0/L56_E_comp/r']),
+                                  np.array(traces_stim['V4_L56_I/0/L56_I_comp/r']),
                                   ))
 
             # TODO: Make this more obvious
             # for compatibility with the Python code, expand the third dimension
-            rate_conn = np.expand_dims(rate_conn, axis=2)
-            # transform the dt from ms to s, for the rest of the analysis
-            s_dt = dt / 1000
-            # perform simulation with background current
-            interareal_analysis(rate_conn, transient, s_dt, minfreq, n_areas, stats)
+            rate_stim = np.expand_dims(rate_stim, axis=2)
+
+            # Perfrom analysis with both rest and stimulated simulation
+            interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq, n_areas, stats)
 
         print('Done')
 

--- a/NeuroML2/GenerateNeuroMLlite.py
+++ b/NeuroML2/GenerateNeuroMLlite.py
@@ -702,10 +702,11 @@ if __name__ == "__main__":
         minfreq_l23 = 30 # Hz
         minfreq_l56 = 3 # Hz
         Iext0 = 2; Iext1= 4 # external injected current
+        areas = ['V1', 'V4']
 
         # for testing purpose generate one single simulation
         if '-analysis' in sys.argv:
-            stats = 6
+            stats = 3
         else:
             stats = 1
 
@@ -715,7 +716,7 @@ if __name__ == "__main__":
             # Run simulation at rest
             sim_rest, net_rest = generate(wee=wee, wei=wei, wie=wie, wii=wii,
                                           i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e,
-                                          areas=['V1', 'V4'], FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
+                                          areas=areas, FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
                                           FB_l5e_l5i=FB_l5e_l5i, FB_l5e_l2e=FB_l5e_l2e,
                                           dt=dt, duration=duration, Iext=[[Iext0, Iext1],[Iext0, Iext1]], count=stat)
             # Run in some simulators
@@ -731,7 +732,7 @@ if __name__ == "__main__":
             Iext_stim = 15
             sim_stim, net_stim = generate(wee=wee, wei=wei, wie=wie, wii=wii,
                                           i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e,
-                                          areas=['V1', 'V4'], FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
+                                          areas=areas, FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
                                           FB_l5e_l5i=FB_l5e_l5i, FB_l5e_l2e=FB_l5e_l2e,
                                           dt=dt, duration=duration, Iext=[[Iext_stim + Iext0, Iext_stim + Iext1], [Iext0, Iext1]],
                                           count=stat)
@@ -779,12 +780,11 @@ if __name__ == "__main__":
             # TODO: Make this more obvious
 
             # Perfrom analysis with both rest and stimulated simulation
-            px20, px2, fx2 = interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq_l23, minfreq_l56,
-                                                 n_areas, stats)
+            px20, px2, px50, px5, fx2 = interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq_l23, minfreq_l56,
+                                                            n_areas, stats)
 
             # Plot the results
-            area = 1 # 0 corresponds to V1; 1 corresponds to V4
-            interareal_plt(area, px20, px2, fx2)
+            interareal_plt(areas, px20, px2, px50, px5, fx2)
 
         print('Done')
 

--- a/NeuroML2/GenerateNeuroMLlite.py
+++ b/NeuroML2/GenerateNeuroMLlite.py
@@ -689,7 +689,7 @@ if __name__ == "__main__":
             plt.show()
             
     elif '-interareal' in sys.argv:
-        from interareal import interareal_analysis
+        from interareal import interareal_analysis, interareal_plt
 
         # Background current simulation.
         # Note: For testing porpose, only the rest simulation is performed if the flag '-analysis' is not
@@ -704,7 +704,7 @@ if __name__ == "__main__":
 
         # for testing purpose generate one single simulation
         if '-analysis' in sys.argv:
-            stats = 8
+            stats = 10
         else:
             stats = 1
 
@@ -741,7 +741,7 @@ if __name__ == "__main__":
                                       simulator=simulator)
             traces_stim, events_stim = nmllr_stim.run_once('/tmp')
 
-            
+
 
             # Save the traces for each different run
             traces_rest_stats.append(traces_rest)
@@ -777,7 +777,11 @@ if __name__ == "__main__":
             # TODO: Make this more obvious
 
             # Perfrom analysis with both rest and stimulated simulation
-            interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq, n_areas, stats)
+            px2, px20, fx2 = interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq, n_areas, stats)
+
+            # Plot the results
+            area = 1 # 0 corresponds to V1; 1 corresponds to V4
+            interareal_plt(area, px20, px2, fx2)
 
         print('Done')
 

--- a/NeuroML2/GenerateNeuroMLlite.py
+++ b/NeuroML2/GenerateNeuroMLlite.py
@@ -54,19 +54,6 @@ def generate(wee = 1.5, wei = -3.25, wie = 3.5, wii = -2.5,
     net.cells.append(l56ecell)
     net.cells.append(l56icell)
 
-    # Background input
-    # Iterate over the different possible areas
-    for area_idx, area in enumerate(areas):
-        input_source_l23 = InputSource(id='iclamp_23_%s' %area,
-                                       neuroml2_input='PulseGenerator',
-                                       parameters={'amplitude':'%snA'%Iext[area_idx][0], 'delay':'0ms', 'duration':'%sms'%duration})
-        net.input_sources.append(input_source_l23)
-        input_source_l56 = InputSource(id='iclamp_56_%s' %area,
-                                       neuroml2_input='PulseGenerator',
-                                       parameters={'amplitude':'%snA'%Iext[area_idx][1], 'delay':'0ms', 'duration':'%sms'%duration})
-
-        net.input_sources.append(input_source_l56)
-
 
     color_str = {'l23e':'.8 0 0','l23i':'0 0 .8',
                  'l56e':'1 .2 0','l56i':'0 .2 1'}
@@ -87,29 +74,6 @@ def generate(wee = 1.5, wei = -3.25, wie = 3.5, wii = -2.5,
 
 
     n_areas = len(areas)
-    pops = []
-    for area in areas:
-        l23 = RectangularRegion(id='%s_L23' %(area), x=0,y=100,z=0,width=10,height=10,depth=10)
-        net.regions.append(l23)
-        l56 = RectangularRegion(id='%s_L56' %(area), x=0,y=0,z=0,width=10,height=10,depth=10)
-        net.regions.append(l56)
-
-        pl23e = Population(id='%s_L23_E' %(area), size=1, component=l23ecell.id, properties={'color':color_str['l23e']},random_layout = RandomLayout(region=l23.id))
-        pops.append(pl23e)
-        pl23i = Population(id='%s_L23_I' %(area), size=1, component=l23icell.id, properties={'color':color_str['l23i']},random_layout = RandomLayout(region=l23.id))
-        pops.append(pl23i)
-
-        pl56e = Population(id='%s_L56_E' %(area), size=1, component=l56ecell.id, properties={'color':color_str['l56e']},random_layout = RandomLayout(region=l56.id))
-        pops.append(pl56e)
-        pl56i = Population(id='%s_L56_I' %(area), size=1, component=l56icell.id, properties={'color':color_str['l56i']},random_layout = RandomLayout(region=l56.id))
-        pops.append(pl56i)
-
-        net.populations.append(pl23e)
-        net.populations.append(pl23i)
-
-        net.populations.append(pl56e)
-        net.populations.append(pl56i)
-
     if n_areas == 1:
         l2e_l2e = 'wee'; l2e_l2i = 'wei'; l2i_l2e = 'wie'; l2i_l2i = 'wii';
         l5e_l5e = 'wee'; l5e_l5i = 'wei'; l5i_l5e = 'wie'; l5i_l5i = 'wii';
@@ -149,26 +113,62 @@ def generate(wee = 1.5, wei = -3.25, wie = 3.5, wii = -2.5,
     else:
         ValueError('Connectivity matrix not defined for more than 2 regions')
 
-    for pre_pop in pops:
-        for post_pop in pops:
-            internal_connections(pops, W, pre_pop, post_pop)
-
-
-
 
     net.synapses.append(Synapse(id='rs',
                                 lems_source_file='Prototypes.xml'))
 
 
-    # Add modulation
-    net.inputs.append(Input(id='modulation_l23_E',
-                            input_source=input_source_l23.id,
-                            population=pl23e.id,
-                            percentage=100))
-    net.inputs.append(Input(id='modulation_l56_E',
-                            input_source=input_source_l56.id,
-                            population=pl56e.id,
-                            percentage=100))
+    # Background input
+    # Iterate over the different possible areas
+    pops = []
+    for area_idx, area in enumerate(areas):
+        # Add populations
+        l23 = RectangularRegion(id='%s_L23' %(area), x=0,y=100,z=0,width=10,height=10,depth=10)
+        net.regions.append(l23)
+        l56 = RectangularRegion(id='%s_L56' %(area), x=0,y=0,z=0,width=10,height=10,depth=10)
+        net.regions.append(l56)
+
+        pl23e = Population(id='%s_L23_E' %(area), size=1, component=l23ecell.id, properties={'color':color_str['l23e']},random_layout = RandomLayout(region=l23.id))
+        pops.append(pl23e)
+        pl23i = Population(id='%s_L23_I' %(area), size=1, component=l23icell.id, properties={'color':color_str['l23i']},random_layout = RandomLayout(region=l23.id))
+        pops.append(pl23i)
+
+        pl56e = Population(id='%s_L56_E' %(area), size=1, component=l56ecell.id, properties={'color':color_str['l56e']},random_layout = RandomLayout(region=l56.id))
+        pops.append(pl56e)
+        pl56i = Population(id='%s_L56_I' %(area), size=1, component=l56icell.id, properties={'color':color_str['l56i']},random_layout = RandomLayout(region=l56.id))
+        pops.append(pl56i)
+
+        net.populations.append(pl23e)
+        net.populations.append(pl23i)
+
+        net.populations.append(pl56e)
+        net.populations.append(pl56i)
+
+        # Add inputs
+        input_source_l23 = InputSource(id='iclamp_23_%s' %area,
+                                       neuroml2_input='PulseGenerator',
+                                       parameters={'amplitude':'%snA'%Iext[area_idx][0], 'delay':'0ms', 'duration':'%sms'%duration})
+        net.input_sources.append(input_source_l23)
+        # Add modulation
+        net.inputs.append(Input(id='modulation_l23_E',
+                                input_source=input_source_l23.id,
+                                population=pl23e.id,
+                                percentage=100))
+        input_source_l56 = InputSource(id='iclamp_56_%s' %area,
+                                       neuroml2_input='PulseGenerator',
+                                       parameters={'amplitude':'%snA'%Iext[area_idx][1], 'delay':'0ms', 'duration':'%sms'%duration})
+
+        net.input_sources.append(input_source_l56)
+        # Add modulation
+        net.inputs.append(Input(id='modulation_l56_E',
+                                input_source=input_source_l56.id,
+                                population=pl56e.id,
+                                percentage=100))
+
+    for pre_pop in pops:
+        for post_pop in pops:
+            internal_connections(pops, W, pre_pop, post_pop)
+
 
 
     print(net)
@@ -704,7 +704,7 @@ if __name__ == "__main__":
 
         # for testing purpose generate one single simulation
         if '-analysis' in sys.argv:
-            stats = 5
+            stats = 8
         else:
             stats = 1
 
@@ -716,15 +716,14 @@ if __name__ == "__main__":
                                           i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e,
                                           areas=['V1', 'V4'], FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
                                           FB_l5e_l5i=FB_l5e_l5i, FB_l5e_l2e=FB_l5e_l2e,
-                                          dt=dt, duration=duration, Iext=[[Iext0, Iext1],[Iext0, Iext1]])
+                                          dt=dt, duration=duration, Iext=[[Iext0, Iext1],[Iext0, Iext1]], count=stat)
             # Run in some simulators
             check_to_generate_or_run(sys.argv, sim_rest)
             simulator = 'jNeuroML'
 
-            nmllr = NeuroMLliteRunner('%s.json' %sim_rest.id,
+            nmllr_rest = NeuroMLliteRunner('%s.json' %sim_rest.id,
                                         simulator=simulator)
-            traces_rest, events_rest = nmllr.run_once('/tmp')
-            traces_rest_stats.append(traces_rest)
+            traces_rest, events_rest = nmllr_rest.run_once('/tmp')
 
             # Run simulation with microsimulation
             # Injection is applied at V1
@@ -735,26 +734,32 @@ if __name__ == "__main__":
                                           FB_l5e_l5i=FB_l5e_l5i, FB_l5e_l2e=FB_l5e_l2e,
                                           dt=dt, duration=duration, Iext=[[Iext_stim + Iext0, Iext_stim + Iext1], [Iext0, Iext1]])
             # Run in some simulators
-            check_to_generate_or_run(sys.argv, sim_rest)
+            check_to_generate_or_run(sys.argv, sim_stim)
             simulator = 'jNeuroML'
 
-            nmllr = NeuroMLliteRunner('%s.json' %sim_rest.id,
+            nmllr_stim = NeuroMLliteRunner('%s.json' %sim_stim.id,
                                       simulator=simulator)
-            traces_stim, events_stim = nmllr.run_once('/tmp')
-            traces_stim_stats.append(traces_rest)
+            traces_stim, events_stim = nmllr_stim.run_once('/tmp')
+
+            
+
+            # Save the traces for each different run
+            traces_rest_stats.append(traces_rest)
+            traces_stim_stats.append(traces_stim)
 
 
         if '-analysis' in sys.argv:
 
             n_areas = 2
+            # Concatenate the simulation results in the same format as the matlab code
             # No stimulus
-            rate_rest_all = np.zeros((len(traces_rest_stats[1]) - 1, len(traces_rest_stats[1]['V1_L23_E/0/L23_E_comp/r']), stats))
+            rate_rest_all = np.zeros((len(traces_rest_stats[0]) - 1, len(traces_rest_stats[0]['V1_L23_E/0/L23_E_comp/r']), stats))
             for stat in range(stats):
                 for idx, key in enumerate(sorted(traces_rest_stats[stat].keys())):
                     if key is not 't':
                         rate_rest_all[idx, :, stat] = traces_rest_stats[stat][key]
             # With stimulus
-            rate_stim_all = np.zeros((len(traces_rest_stats[1]) - 1, len(traces_rest_stats[1]['V1_L23_E/0/L23_E_comp/r']), stats))
+            rate_stim_all = np.zeros((len(traces_rest_stats[0]) - 1, len(traces_rest_stats[0]['V1_L23_E/0/L23_E_comp/r']), stats))
             for stat in range(stats):
                 for idx, key in enumerate(sorted(traces_stim_stats[stat].keys())):
                     if key is not 't':
@@ -763,29 +768,13 @@ if __name__ == "__main__":
             # TODO: Make this more obvious
             # for compatibility with the Python code, expand the third dimension
             rate_rest = np.expand_dims(rate_rest_all, axis=2)
+            rate_stim = np.expand_dims(rate_stim_all, axis=2)
             # transform the dt from ms to s, for the rest of the analysis
             s_dt = dt / 1000
             # perform simulation with background current
 
-            # TODO: Improve the generalisation of the code
-            # for key in traces.keys():
-            #     if key is not 't':
-            #         curr_array = np.array(traces[key])
-            #         rate_conn = np.stack([rate_conn, curr_array], axis=0)
-            rate_stim = np.array([])
-            rate_stim = np.stack((np.array(traces_stim['V1_L23_E/0/L23_E_comp/r']),
-                                  np.array(traces_stim['V1_L23_I/0/L23_I_comp/r']),
-                                  np.array(traces_stim['V1_L56_E/0/L56_E_comp/r']),
-                                  np.array(traces_stim['V1_L56_I/0/L56_I_comp/r']),
-                                  np.array(traces_stim['V4_L23_E/0/L23_E_comp/r']),
-                                  np.array(traces_stim['V4_L23_I/0/L23_I_comp/r']),
-                                  np.array(traces_stim['V4_L56_E/0/L56_E_comp/r']),
-                                  np.array(traces_stim['V4_L56_I/0/L56_I_comp/r']),
-                                  ))
-
+            #rate_stim = np.stack([traces_stim[key] for key in sorted(traces_stim.keys()) if key is not 't'])
             # TODO: Make this more obvious
-            # for compatibility with the Python code, expand the third dimension
-            rate_stim = np.expand_dims(rate_stim, axis=2)
 
             # Perfrom analysis with both rest and stimulated simulation
             interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq, n_areas, stats)

--- a/NeuroML2/GenerateNeuroMLlite.py
+++ b/NeuroML2/GenerateNeuroMLlite.py
@@ -699,12 +699,13 @@ if __name__ == "__main__":
         dt = 2e-01
         transient = 5
         duration = 4e04
-        minfreq = 30 # Hz
+        minfreq_l23 = 30 # Hz
+        minfreq_l56 = 3 # Hz
         Iext0 = 2; Iext1= 4 # external injected current
 
         # for testing purpose generate one single simulation
         if '-analysis' in sys.argv:
-            stats = 10
+            stats = 6
         else:
             stats = 1
 
@@ -732,7 +733,8 @@ if __name__ == "__main__":
                                           i_l5e_l2i=l5e_l2i, i_l2e_l5e=l2e_l5e,
                                           areas=['V1', 'V4'], FF_l2e_l2e=FF_l2e_l2e, FB_l5e_l2i=FB_l5e_l2i, FB_l5e_l5e=FB_l5e_l5e,
                                           FB_l5e_l5i=FB_l5e_l5i, FB_l5e_l2e=FB_l5e_l2e,
-                                          dt=dt, duration=duration, Iext=[[Iext_stim + Iext0, Iext_stim + Iext1], [Iext0, Iext1]])
+                                          dt=dt, duration=duration, Iext=[[Iext_stim + Iext0, Iext_stim + Iext1], [Iext0, Iext1]],
+                                          count=stat)
             # Run in some simulators
             check_to_generate_or_run(sys.argv, sim_stim)
             simulator = 'jNeuroML'
@@ -777,7 +779,8 @@ if __name__ == "__main__":
             # TODO: Make this more obvious
 
             # Perfrom analysis with both rest and stimulated simulation
-            px2, px20, fx2 = interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq, n_areas, stats)
+            px20, px2, fx2 = interareal_analysis(rate_rest, rate_stim, transient, s_dt, minfreq_l23, minfreq_l56,
+                                                 n_areas, stats)
 
             # Plot the results
             area = 1 # 0 corresponds to V1; 1 corresponds to V4

--- a/Python/Mejias-2016.py
+++ b/Python/Mejias-2016.py
@@ -222,15 +222,7 @@ if __name__ == "__main__":
         Nareas = 2
         t = np.arange(dt, tstop + dt - transient, dt)
 
-        # define interlaminar synaptic coupling strenghts
-        J_2e = 1; J_2i = 0
-        J_5e = 0; J_5i = 0.75
-
-        J = np.array([[wee, wie, J_5e,   0],
-                      [wei, wii, J_5i,   0],
-                      [J_2e, 0,   wee, wie],
-                      [J_2i, 0,   wei, wii]])
-
+        tau, sig, J, Iext, Ibgk = get_network_configuration('interareal', noconns=False)
 
         # Interareal connectivity
 

--- a/Python/helper_functions.py
+++ b/Python/helper_functions.py
@@ -117,6 +117,11 @@ def get_network_configuration(analysis_type, noconns=False):
         J_2e = 0; J_2i = 0
         J_5e = 0; J_5i = 0
 
+    elif analysis_type == 'interareal':
+        # define interlaminar synaptic coupling strenghts
+        J_2e = 1; J_2i = 0
+        J_5e = 0; J_5i = 0.75
+
     else:
         raise Exception('This type of analysis is not implemented')
     J = np.array([[wee, wie, J_5e,   0],
@@ -159,6 +164,34 @@ def calculate_periodogram(re, transient, dt):
                                     scaling='density')
     # print('Done calculating Periodogram!')
     return pxx, fxx
+
+def find_peak_frequency(fxx,pxx, min_freq, restate):
+    # find the frequency of the oscillations
+    z = np.where(fxx > min_freq)
+    pxx_freq = pxx[z]
+    fxx_freq = fxx[z]
+
+    # Locate peaks in the spectrum
+    loc = signal.find_peaks(pxx_freq)[0]
+    pks = pxx_freq[loc]
+    z = len(loc)
+    # if there is at least one peak
+    if z > 1:
+        # find index of the highest peak
+        z3 = np.argmax(pks)
+        # find location in Hz of the higest peak
+        frequency = fxx_freq[loc[z3]]
+        # power of the peak in the spectrum
+        amplitudeA = pxx_freq[loc[z3]]
+    else:
+        frequency = 0
+        amplitudeA = 0
+
+    # calculate excitatory mean firing rate and the amplitute of oscillations
+    mfr = np.mean(restate)
+    amplitudeB = 2 * np.std(restate)
+    amplitudeC = np.max(restate) - np.min(restate)
+    return frequency, amplitudeA, amplitudeB, amplitudeC
 
 
 def compress_data(pxx, fxx, bin):

--- a/Python/helper_functions.py
+++ b/Python/helper_functions.py
@@ -165,7 +165,7 @@ def calculate_periodogram(re, transient, dt):
     # print('Done calculating Periodogram!')
     return pxx, fxx
 
-def find_peak_frequency(fxx,pxx, min_freq, restate):
+def find_peak_frequency(fxx, pxx, min_freq, restate):
     # find the frequency of the oscillations
     z = np.where(fxx > min_freq)
     pxx_freq = pxx[z]
@@ -192,6 +192,33 @@ def find_peak_frequency(fxx,pxx, min_freq, restate):
     amplitudeB = 2 * np.std(restate)
     amplitudeC = np.max(restate) - np.min(restate)
     return frequency, amplitudeA, amplitudeB, amplitudeC
+
+
+def plt_filled_std(ax, fxx_plt, data_mean, data_std, color, label):
+    # calculate upper and lower bounds of the plot
+    cis = (data_mean - data_std, data_mean + data_std)
+    # plot filled area
+    ax.fill_between(fxx_plt, cis[0], cis[1], alpha=0.2, color=color)
+    # plot mean
+    ax.plot(fxx_plt, data_mean, color=color, linewidth=2, label=label)
+    ax.margins(x=0)
+
+
+def matlab_smooth(data, window_size):
+    # assumes the data is one dimensional
+    n = data.shape[0]
+    c = signal.lfilter(np.ones(window_size)/window_size, 1, data)
+    idx_begin = range(0, window_size - 2)
+    cbegin = data[idx_begin].cumsum()
+    # select every second elemeent and divide by their index
+    cbegin = cbegin[0::2] / range(1, window_size - 1, 2)
+    # select the list backwards
+    idx_end = range(n-1, n-window_size + 1, -1)
+    cend = data[idx_end].cumsum()
+    # select every other element until the end backwards
+    cend = cend[-1::-2] / (range(window_size - 2, 0, -2))
+    c = np.concatenate([cbegin, c[window_size-1:], cend])
+    return c
 
 
 def compress_data(pxx, fxx, bin):

--- a/Python/helper_functions.py
+++ b/Python/helper_functions.py
@@ -165,6 +165,7 @@ def calculate_periodogram(re, transient, dt):
     # print('Done calculating Periodogram!')
     return pxx, fxx
 
+
 def find_peak_frequency(fxx, pxx, min_freq, restate):
     # find the frequency of the oscillations
     z = np.where(fxx > min_freq)

--- a/Python/interareal.py
+++ b/Python/interareal.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+
+from calculate_rate import calculate_rate
+from helper_functions import calculate_periodogram, find_peak_frequency
+
+
+def interareal_simulation(t, dt, tstop, J, W, tau, Iext, Ibkg, sig, noise):
+    # feedback selectiviyt
+    Gw = 1
+
+    Nareas = 2
+    stat = 10 # TODO: Number of time to repeat the analysis
+    powerpeak = np.zeros((4, stat))
+    freqpeak = np.zeros((4, stat))
+    nobs = t.shpae[0]
+    binx = 10; eta=.2
+    X = np.zeros((Nareas, int(round(nobs/binx)), stat))
+
+    for jj in range(stat):
+        calculate_rate(t, dt, tstop, J, tau, sig, Iext, Ibkg, noise, Nareas, W, Gw)
+        # adapt the code so that it can take an array of Iext and return
+        # mean input (if interareal_simulation). Interareal simulation also
+        # takes an aditional argument W
+
+    return fx2, px2, fx5, px5, powerpeak, fpeak, mean_input
+
+def trialstat(rate, transient, dt, minfreq, nareas, stats):
+    '''Main Interareal Analysis
+        rate: Simulated rate
+        transient: Number of points to averate over
+        dt: dt of the simulation
+        minfrequence: Frequencies below this threshold get discarded
+
+    '''
+
+    # To obtain some statistics salculate frequency and amplitude for multiple runs
+    nlayers = 2 # we are only interested on the two excitatory layers
+
+    powerpeak = np.zeros((nareas * nlayers, stats))
+    freqpeak = np.zeros((nareas * nlayers, stats))
+    # Calculate periodeogram to get the shape of the array
+    pxx_t, fxx_t = calculate_periodogram(rate[0, :, 0], transient, dt)
+    px2 = np.zeros((len(pxx_t), nareas, stats))
+    fx2 = np.zeros((len(fxx_t), nareas, stats))
+    px5 = np.zeros((len(pxx_t), nareas, stats))
+    fx5 = np.zeros((len(fxx_t), nareas, stats))
+
+    for stat in range(stats):
+        k = 0
+        for area in range(nareas):
+            # Calculate power spectrum for the excitatory population only
+            pxx2, fxx2 = calculate_periodogram(rate[k, :, 0], transient, dt)
+
+            # concatenate the results
+            px2[:, area, stat] = pxx2
+            fx2[:, area, stat] = fxx2
+
+            frequency_l23, amplitudeA_l23, _, _ = \
+                find_peak_frequency(fxx2, pxx2, minfreq, rate[k, :, 0])
+
+            powerpeak[k, stat] = amplitudeA_l23
+            freqpeak[k, stat] = frequency_l23
+
+            k += 1
+
+            pxx5, fxx5 = calculate_periodogram(rate[k+1, :, 0], transient, dt)
+            # concatenate the results
+            px5[:, area, stat] = pxx5
+            fx5[:, area, stat] = fxx5
+
+            frequency_l56, amplitudeA_l56, _, _ = \
+                find_peak_frequency(fxx5, pxx5, minfreq, rate[k+1, :, 0])
+
+            powerpeak[k, stat] = amplitudeA_l56
+            freqpeak[k, stat] = frequency_l56
+        return fx2, px2, fx5, px5, powerpeak, freqpeak
+
+def interareal_analysis(rate, transient, dt, minfreq, nareas, stats):
+
+    # Analysis of the simulation at rest
+    fx20, px20, fx50, px50, powerpeak0, fpeak0 = trialstat(rate, transient, dt, minfreq, nareas, stats)
+    # Analysis after microstimulation
+
+
+
+

--- a/Python/interareal.py
+++ b/Python/interareal.py
@@ -98,7 +98,7 @@ def interareal_analysis(rate_rest, rate_stim, transient, dt, minfreq_l23, minfre
 
     return px20, px2, px50, px5, fx2
 
-def plot_powerspectrum(filter, area, layer, px0, px, fx2, lcolours):
+def plot_powerspectrum( area, layer, px0, px, fx2, lcolours, stimulated_area):
     '''
     Plot power spectrum for the rest and stimulated layers   for the different layers
 
@@ -125,11 +125,14 @@ def plot_powerspectrum(filter, area, layer, px0, px, fx2, lcolours):
 
     if layer == 'l23':
         resbin = 20
-        xlim = [20, 80]
-        ylim = [0, .006]
+        filter = [20, 80]
+        if stimulated_area == 'stimulate_V1':
+            ylim = [0, .006]
+        elif stimulated_area == 'stimulate_V4':
+            ylim = [0, .0015]
     elif layer == 'l56':
         resbin = 10
-        xlim = [5, 20]
+        filter = [5, 20]
         ylim = [0, .03]
     else:
         IOError('Passed layer is not l23 or l56. Please check your input.')
@@ -175,24 +178,28 @@ def plot_powerspectrum(filter, area, layer, px0, px, fx2, lcolours):
     fig, ax = plt.subplots(1)
     plt_filled_std(ax, fx0[1:-1:resbin], pxx20[1:-1:resbin], pxx20sig[1:-1:resbin], lcolours[0], 'rest')
     plt_filled_std(ax, fx[1:-1:resbin], pxx2[1:-1:resbin], pxx2sig[1:-1:resbin], lcolours[1], 'stimulus')
-    plt.xlim(xlim)
+    plt.xlim(filter)
     plt.ylim(ylim)
     plt.xlabel('Frequency(Hz)')
-    plt.ylabel('Power (resp. rest)')
+    plt.ylabel('V4 %s Power' %layer)
     plt.legend()
-    plt.savefig('interareal/%s_%s.png' %(area, layer))
+    plt.savefig('interareal/%s_layer_%s_%s.png' %(stimulated_area, area, layer))
 
 
-def interareal_plt(areas, px20, px2, px50, px5, fx2):
+def interareal_plt(areas, px20, px2, px50, px5, fx2, stimulated_area):
     '''
 
     '''
 
-    # Plot the results only for V4.
-    filter = [20, 80]
+    if stimulated_area == 'stimulate_V4':
+        recording_area = areas[0]
+    elif stimulated_area == 'stimulate_V1':
+        recording_area = areas[1]
+    else:
+        IOError('Stimulated area is not defined.')
     lcolours = ['#1F5E43', '#31C522', '#2242C5']
-    plot_powerspectrum(filter, areas[1], 'l23', px20, px2, fx2, lcolours)
-    plot_powerspectrum(filter, areas[1], 'l56', px50, px5, fx2, lcolours)
+    plot_powerspectrum(recording_area, 'l23', px20, px2, fx2, lcolours, stimulated_area)
+    plot_powerspectrum(recording_area, 'l56', px50, px5, fx2, lcolours, stimulated_area)
 
 
 

--- a/Python/interareal.py
+++ b/Python/interareal.py
@@ -26,7 +26,7 @@ def interareal_simulation(t, dt, tstop, J, W, tau, Iext, Ibkg, sig, noise):
 
     return fx2, px2, fx5, px5, powerpeak, fpeak, mean_input
 
-def trialstat(rate, transient, dt, minfreq, nareas, stats):
+def trialstat(rate, transient, dt, minfreq_l23, minfreq_l56, nareas, stats):
     '''Main Interareal Analysis
         rate: Simulated rate
         transient: Number of points to averate over
@@ -57,7 +57,7 @@ def trialstat(rate, transient, dt, minfreq, nareas, stats):
             fx2[:, area, stat] = fxx2
 
             frequency_l23, amplitudeA_l23, _, _ = \
-                find_peak_frequency(fxx2, pxx2, minfreq, rate[area * 4, :, 0, stat])
+                find_peak_frequency(fxx2, pxx2, minfreq_l23, rate[area * 4, :, 0, stat])
 
             powerpeak[k, stat] = amplitudeA_l23
             freqpeak[k, stat] = frequency_l23
@@ -65,25 +65,25 @@ def trialstat(rate, transient, dt, minfreq, nareas, stats):
             k += 1
 
             # Calculate power spectrum for the excitatory population from layer L56
-            pxx5, fxx5 = calculate_periodogram(rate[area * 4 + 3, :, 0, stat], transient, dt)
+            pxx5, fxx5 = calculate_periodogram(rate[area * 4 + 2, :, 0, stat], transient, dt)
             # concatenate the results
             px5[:, area, stat] = pxx5
             fx5[:, area, stat] = fxx5
 
             frequency_l56, amplitudeA_l56, _, _ = \
-                find_peak_frequency(fxx5, pxx5, minfreq, rate[area * 4 + 3, :, 0, stat])
+                find_peak_frequency(fxx5, pxx5, minfreq_l56, rate[area * 4 + 2, :, 0, stat])
 
             powerpeak[k, stat] = amplitudeA_l56
             freqpeak[k, stat] = frequency_l56
             k += 1
     return fx2, px2, fx5, px5, powerpeak, freqpeak
 
-def interareal_analysis(rate_rest, rate_stim, transient, dt, minfreq, nareas, stats):
+def interareal_analysis(rate_rest, rate_stim, transient, dt, minfreq_l23, minfreq_l56, nareas, stats):
 
     # Analysis of the simulation at rest
-    fx20, px20, fx50, px50, powerpeak0, fpeak0 = trialstat(rate_rest, transient, dt, minfreq, nareas, stats)
+    fx20, px20, fx50, px50, powerpeak0, fpeak0 = trialstat(rate_rest, transient, dt, minfreq_l23, minfreq_l56, nareas, stats)
     # Analysis of the simulation with additional stimulation
-    fx2, px2, fx5, px5, powerpeak1, fpeak1 = trialstat(rate_stim, transient, dt, minfreq, nareas, stats)
+    fx2, px2, fx5, px5, powerpeak1, fpeak1 = trialstat(rate_stim, transient, dt, minfreq_l23, minfreq_l56, nareas, stats)
 
     # Analysis after microstimulation
     # significance
@@ -92,8 +92,8 @@ def interareal_analysis(rate_rest, rate_stim, transient, dt, minfreq, nareas, st
     gamma0 = powerpeak0[z1, :]; gamma1 = powerpeak1[z1, :]
     alpha0 = powerpeak0[z2, :]; alpha1 = powerpeak1[z2, :]
 
-    statistic, pvalue = ttest_ind(gamma0, gamma1)
-    statistic2, pvalue2 = ttest_ind(alpha0, alpha1)
+    statistic, pgamma = ttest_ind(gamma0, gamma1)
+    statistic2, palpha = ttest_ind(alpha0, alpha1)
 
     return px20, px2, fx2
 
@@ -110,20 +110,20 @@ def interareal_plt(area, px20, px2, fx2):
     ## Analysis for rest model
     # reshuffle the px20 data so that you have stats x time points for the area of interst
     pz0 = np.squeeze(np.transpose(px20[:, area, :]))
-    fx = np.transpose(fx2[:, area, 0])
+    fx0 = np.transpose(fx2[:, area, 0])
     # smooth the data
     # Note: The matlab code transforms an even-window size into an odd number by subtracting by one.
     # So for simplicity I already define the window size as an odd number
     window_size = 99
     pxx0 = []
-    lcolours = ['#588ef3', '#f35858', '#bd58f3']
+    lcolours = ['#1F5E43', '#31C522', '#2242C5']
     for i in range(len(pz0)):
         pxx0.append(matlab_smooth(pz0[i, :], window_size))
     pxx0 = np.asarray(pxx0)
     pxx20 = np.mean(pxx0, axis=0)
     pxx20sig = np.std(pxx0, axis=0)
 
-    fxx_plt_idx = np.where((fx > 20) & (fx < 80))
+    fxx_plt_idx = np.where((fx0 > 20) & (fx0 < 80))
     z1 = pxx20[fxx_plt_idx]
     z2 = pxx20sig[fxx_plt_idx]
     b2 = np.argmax(z1)
@@ -138,7 +138,7 @@ def interareal_plt(area, px20, px2, fx2):
         pxx.append(matlab_smooth(pz[i, :], window_size))
     pxx = np.asarray(pxx)
     pxx2 = np.mean(pxx, axis=0)
-    pxx2sig = np.mean(pxx, axis=0)
+    pxx2sig = np.std(pxx, axis=0)
     fxx_plt_idx = np.where((fx > 20) & (fx < 80))
     z1 = pxx2[fxx_plt_idx]
     z2 = pxx2sig[fxx_plt_idx]
@@ -149,14 +149,14 @@ def interareal_plt(area, px20, px2, fx2):
     # Plot results for V4 L2/3
     fig, ax = plt.subplots(1)
     resbin2 = 20
-    plt_filled_std(ax, fx[1:-1:resbin2], pxx20[1:-1:resbin2], pxx20sig[1:-1:resbin2], lcolours[0], 'rest')
+    plt_filled_std(ax, fx0[1:-1:resbin2], pxx20[1:-1:resbin2], pxx20sig[1:-1:resbin2], lcolours[0], 'rest')
     plt_filled_std(ax, fx[1:-1:resbin2], pxx2[1:-1:resbin2], pxx2sig[1:-1:resbin2], lcolours[1], 'stimulus')
     plt.xlim([20, 80])
     plt.ylim([0, .006])
     plt.xlabel('Frequency(Hz)')
     plt.ylabel('Power (resp. rest)')
     plt.legend()
-    plt.show()
+    plt.savefig('interareal/V4_l23.png')
 
     filter = [20, 80]
     def plot_plot(filter):
@@ -165,15 +165,15 @@ def interareal_plt(area, px20, px2, fx2):
         return fx, pxx, pxx0, pxxsig, pxx0sig, z1, z2
 
     # Plot results for V4 L5/6
-    fig, ax = plt.subplots(1)
-    resbin5 = 10
-    plt_filled_std(ax, fx[1:-1:resbin5], pxx20[1:-1:resbin5], pxx20sig[1:-1:resbin5], lcolours[0], 'rest')
-    plt_filled_std(ax, fx[1:-1:resbin5], pxx2[1:-1:resbin5], pxx2sig[1:-1:resbin5], lcolours[1], 'stimulus')
-    plt.xlim([5, 20])
-    plt.ylim([0, .025])
-    plt.xlabel('Frequency(Hz)')
-    plt.ylabel('Power (resp. rest)')
-    plt.legend()
-    plt.show()
+    # fig, ax = plt.subplots(1)
+    # resbin5 = 10
+    # plt_filled_std(ax, fx[1:-1:resbin5], pxx20[1:-1:resbin5], pxx20sig[1:-1:resbin5], lcolours[0], 'rest')
+    # plt_filled_std(ax, fx[1:-1:resbin5], pxx2[1:-1:resbin5], pxx2sig[1:-1:resbin5], lcolours[1], 'stimulus')
+    # plt.xlim([5, 20])
+    # plt.ylim([0, .025])
+    # plt.xlabel('Frequency(Hz)')
+    # plt.ylabel('Power (resp. rest)')
+    # plt.legend()
+    # plt.show()
 
 

--- a/Python/interareal.py
+++ b/Python/interareal.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.stats import ttest_ind
 
 
 from calculate_rate import calculate_rate
@@ -50,37 +51,48 @@ def trialstat(rate, transient, dt, minfreq, nareas, stats):
         k = 0
         for area in range(nareas):
             # Calculate power spectrum for the excitatory population only
-            pxx2, fxx2 = calculate_periodogram(rate[k, :, 0], transient, dt)
+            pxx2, fxx2 = calculate_periodogram(rate[area * 4, :, 0], transient, dt)
 
             # concatenate the results
             px2[:, area, stat] = pxx2
             fx2[:, area, stat] = fxx2
 
             frequency_l23, amplitudeA_l23, _, _ = \
-                find_peak_frequency(fxx2, pxx2, minfreq, rate[k, :, 0])
+                find_peak_frequency(fxx2, pxx2, minfreq, rate[0, :, 0])
 
             powerpeak[k, stat] = amplitudeA_l23
             freqpeak[k, stat] = frequency_l23
 
             k += 1
 
-            pxx5, fxx5 = calculate_periodogram(rate[k+1, :, 0], transient, dt)
+            pxx5, fxx5 = calculate_periodogram(rate[area * 4 + 3, :, 0], transient, dt)
             # concatenate the results
             px5[:, area, stat] = pxx5
             fx5[:, area, stat] = fxx5
 
             frequency_l56, amplitudeA_l56, _, _ = \
-                find_peak_frequency(fxx5, pxx5, minfreq, rate[k+1, :, 0])
+                find_peak_frequency(fxx5, pxx5, minfreq, rate[3, :, 0])
 
             powerpeak[k, stat] = amplitudeA_l56
             freqpeak[k, stat] = frequency_l56
-        return fx2, px2, fx5, px5, powerpeak, freqpeak
+            k += 1
+    return fx2, px2, fx5, px5, powerpeak, freqpeak
 
-def interareal_analysis(rate, transient, dt, minfreq, nareas, stats):
+def interareal_analysis(rate_rest, rate_stim, transient, dt, minfreq, nareas, stats):
 
     # Analysis of the simulation at rest
-    fx20, px20, fx50, px50, powerpeak0, fpeak0 = trialstat(rate, transient, dt, minfreq, nareas, stats)
+    fx20, px20, fx50, px50, powerpeak0, fpeak0 = trialstat(rate_rest, transient, dt, minfreq, nareas, stats)
+    # Analysis of the simulation with additional stimulation
+    fx2, px2, fx5, px5, powerpeak1, fpeak1 = trialstat(rate_stim, transient, dt, minfreq, nareas, stats)
+
     # Analysis after microstimulation
+    # significance
+    z1 = 3; z2 = 4; # Excitatory and inhibiory layers L5/6
+    gamma0 = powerpeak0[z1, :]; gamma1 = powerpeak1[z1, :];
+    alpha0 = powerpeak0[z2, :]; alpha1 = powerpeak1[z2, :];
+
+    statistic, pvalue = ttest_ind(gamma0, gamma1)
+    statistic2, pvalue2 = ttest_ind(alpha0, alpha1)
 
 
 

--- a/Python/interareal.py
+++ b/Python/interareal.py
@@ -1,9 +1,9 @@
 import numpy as np
 from scipy.stats import ttest_ind
-
+import matplotlib.pylab as plt
 
 from calculate_rate import calculate_rate
-from helper_functions import calculate_periodogram, find_peak_frequency
+from helper_functions import calculate_periodogram, find_peak_frequency, matlab_smooth, plt_filled_std
 
 
 def interareal_simulation(t, dt, tstop, J, W, tau, Iext, Ibkg, sig, noise):
@@ -35,13 +35,12 @@ def trialstat(rate, transient, dt, minfreq, nareas, stats):
 
     '''
 
-    # To obtain some statistics salculate frequency and amplitude for multiple runs
-    nlayers = 2 # we are only interested on the two excitatory layers
+    # To obtain some statistics calculate frequency and amplitude for multiple runs
 
-    powerpeak = np.zeros((nareas * nlayers, stats))
-    freqpeak = np.zeros((nareas * nlayers, stats))
+    powerpeak = np.zeros((nareas * nareas, stats))
+    freqpeak = np.zeros((nareas * nareas, stats))
     # Calculate periodeogram to get the shape of the array
-    pxx_t, fxx_t = calculate_periodogram(rate[0, :, 0], transient, dt)
+    pxx_t, fxx_t = calculate_periodogram(rate[0, :, 0, 0], transient, dt)
     px2 = np.zeros((len(pxx_t), nareas, stats))
     fx2 = np.zeros((len(fxx_t), nareas, stats))
     px5 = np.zeros((len(pxx_t), nareas, stats))
@@ -50,28 +49,29 @@ def trialstat(rate, transient, dt, minfreq, nareas, stats):
     for stat in range(stats):
         k = 0
         for area in range(nareas):
-            # Calculate power spectrum for the excitatory population only
-            pxx2, fxx2 = calculate_periodogram(rate[area * 4, :, 0], transient, dt)
+            # Calculate power spectrum for the excitatory population from layer L23
+            pxx2, fxx2 = calculate_periodogram(rate[area * 4, :, 0, stat], transient, dt)
 
             # concatenate the results
             px2[:, area, stat] = pxx2
             fx2[:, area, stat] = fxx2
 
             frequency_l23, amplitudeA_l23, _, _ = \
-                find_peak_frequency(fxx2, pxx2, minfreq, rate[0, :, 0])
+                find_peak_frequency(fxx2, pxx2, minfreq, rate[area * 4, :, 0, stat])
 
             powerpeak[k, stat] = amplitudeA_l23
             freqpeak[k, stat] = frequency_l23
 
             k += 1
 
-            pxx5, fxx5 = calculate_periodogram(rate[area * 4 + 3, :, 0], transient, dt)
+            # Calculate power spectrum for the excitatory population from layer L56
+            pxx5, fxx5 = calculate_periodogram(rate[area * 4 + 3, :, 0, stat], transient, dt)
             # concatenate the results
             px5[:, area, stat] = pxx5
             fx5[:, area, stat] = fxx5
 
             frequency_l56, amplitudeA_l56, _, _ = \
-                find_peak_frequency(fxx5, pxx5, minfreq, rate[3, :, 0])
+                find_peak_frequency(fxx5, pxx5, minfreq, rate[area * 4 + 3, :, 0, stat])
 
             powerpeak[k, stat] = amplitudeA_l56
             freqpeak[k, stat] = frequency_l56
@@ -87,13 +87,93 @@ def interareal_analysis(rate_rest, rate_stim, transient, dt, minfreq, nareas, st
 
     # Analysis after microstimulation
     # significance
-    z1 = 3; z2 = 4; # Excitatory and inhibiory layers L5/6
-    gamma0 = powerpeak0[z1, :]; gamma1 = powerpeak1[z1, :];
-    alpha0 = powerpeak0[z2, :]; alpha1 = powerpeak1[z2, :];
+    #  Note: We are using -1 because Python starts with 0 indexing
+    z1 = 3-1; z2 = 4-1; # Excitatory and inhibitory layers L5/6 (feedforward)
+    gamma0 = powerpeak0[z1, :]; gamma1 = powerpeak1[z1, :]
+    alpha0 = powerpeak0[z2, :]; alpha1 = powerpeak1[z2, :]
 
     statistic, pvalue = ttest_ind(gamma0, gamma1)
     statistic2, pvalue2 = ttest_ind(alpha0, alpha1)
 
+    return px20, px2, fx2
 
+def interareal_plt(area, px20, px2, fx2):
+    '''
+
+    area: 0 for V1 and 2 for V2
+    '''
+
+    barrasgamma = np.zeros((2,2))
+    barrasalpha = np.zeros((2,2))
+
+
+    ## Analysis for rest model
+    # reshuffle the px20 data so that you have stats x time points for the area of interst
+    pz0 = np.squeeze(np.transpose(px20[:, area, :]))
+    fx = np.transpose(fx2[:, area, 0])
+    # smooth the data
+    # Note: The matlab code transforms an even-window size into an odd number by subtracting by one.
+    # So for simplicity I already define the window size as an odd number
+    window_size = 99
+    pxx0 = []
+    lcolours = ['#588ef3', '#f35858', '#bd58f3']
+    for i in range(len(pz0)):
+        pxx0.append(matlab_smooth(pz0[i, :], window_size))
+    pxx0 = np.asarray(pxx0)
+    pxx20 = np.mean(pxx0, axis=0)
+    pxx20sig = np.std(pxx0, axis=0)
+
+    fxx_plt_idx = np.where((fx > 20) & (fx < 80))
+    z1 = pxx20[fxx_plt_idx]
+    z2 = pxx20sig[fxx_plt_idx]
+    b2 = np.argmax(z1)
+    barrasgamma[0, 0] = z1[b2]
+    barrasgamma[0, 1] = z2[b2]
+
+    ## Analysis for model with stimulus
+    pz = np.squeeze(np.transpose(px2[:, area, :]))
+    fx = np.transpose(fx2[:, area, 1])
+    pxx = []
+    for i in range(len(pz)):
+        pxx.append(matlab_smooth(pz[i, :], window_size))
+    pxx = np.asarray(pxx)
+    pxx2 = np.mean(pxx, axis=0)
+    pxx2sig = np.mean(pxx, axis=0)
+    fxx_plt_idx = np.where((fx > 20) & (fx < 80))
+    z1 = pxx2[fxx_plt_idx]
+    z2 = pxx2sig[fxx_plt_idx]
+    b2 = np.argmax(z1)
+    barrasgamma[1, 0] = z1[b2]
+    barrasgamma[1, 1] = z2[b2]
+
+    # Plot results for V4 L2/3
+    fig, ax = plt.subplots(1)
+    resbin2 = 20
+    plt_filled_std(ax, fx[1:-1:resbin2], pxx20[1:-1:resbin2], pxx20sig[1:-1:resbin2], lcolours[0], 'rest')
+    plt_filled_std(ax, fx[1:-1:resbin2], pxx2[1:-1:resbin2], pxx2sig[1:-1:resbin2], lcolours[1], 'stimulus')
+    plt.xlim([20, 80])
+    plt.ylim([0, .006])
+    plt.xlabel('Frequency(Hz)')
+    plt.ylabel('Power (resp. rest)')
+    plt.legend()
+    plt.show()
+
+    filter = [20, 80]
+    def plot_plot(filter):
+
+
+        return fx, pxx, pxx0, pxxsig, pxx0sig, z1, z2
+
+    # Plot results for V4 L5/6
+    fig, ax = plt.subplots(1)
+    resbin5 = 10
+    plt_filled_std(ax, fx[1:-1:resbin5], pxx20[1:-1:resbin5], pxx20sig[1:-1:resbin5], lcolours[0], 'rest')
+    plt_filled_std(ax, fx[1:-1:resbin5], pxx2[1:-1:resbin5], pxx2sig[1:-1:resbin5], lcolours[1], 'stimulus')
+    plt.xlim([5, 20])
+    plt.ylim([0, .025])
+    plt.xlabel('Frequency(Hz)')
+    plt.ylabel('Power (resp. rest)')
+    plt.legend()
+    plt.show()
 
 

--- a/Python/interareal.py
+++ b/Python/interareal.py
@@ -78,6 +78,7 @@ def trialstat(rate, transient, dt, minfreq_l23, minfreq_l56, nareas, stats):
             k += 1
     return fx2, px2, fx5, px5, powerpeak, freqpeak
 
+
 def interareal_analysis(rate_rest, rate_stim, transient, dt, minfreq_l23, minfreq_l56, nareas, stats):
 
     # Analysis of the simulation at rest
@@ -95,35 +96,59 @@ def interareal_analysis(rate_rest, rate_stim, transient, dt, minfreq_l23, minfre
     statistic, pgamma = ttest_ind(gamma0, gamma1)
     statistic2, palpha = ttest_ind(alpha0, alpha1)
 
-    return px20, px2, fx2
+    return px20, px2, px50, px5, fx2
 
-def interareal_plt(area, px20, px2, fx2):
+def plot_powerspectrum(filter, area, layer, px0, px, fx2, lcolours):
     '''
+    Plot power spectrum for the rest and stimulated layers   for the different layers
 
-    area: 0 for V1 and 2 for V2
+    inputs:
+        filter: [lower, upper frequence in Hz]
+        area: Area to be analysed
+        px0: rate with no stimulation
+        px: rate with stimulation
+        fx2:
+        lcolours: List of colours to use for plotting
     '''
 
     barrasgamma = np.zeros((2,2))
     barrasalpha = np.zeros((2,2))
 
+    # Set configuration according to passed layers
+    window_size = 99
+    if area == 'V1':
+        area_idx = 0
+    elif area == 'V4':
+        area_idx = 1
+    else:
+        IOError('Rate in this area was not simulated. Please, check your area again.')
+
+    if layer == 'l23':
+        resbin = 20
+        xlim = [20, 80]
+        ylim = [0, .006]
+    elif layer == 'l56':
+        resbin = 10
+        xlim = [5, 20]
+        ylim = [0, .03]
+    else:
+        IOError('Passed layer is not l23 or l56. Please check your input.')
 
     ## Analysis for rest model
     # reshuffle the px20 data so that you have stats x time points for the area of interst
-    pz0 = np.squeeze(np.transpose(px20[:, area, :]))
-    fx0 = np.transpose(fx2[:, area, 0])
+    pz0 = np.squeeze(np.transpose(px0[:, area_idx, :]))
+    fx0 = np.transpose(fx2[:, area_idx, 0])
     # smooth the data
     # Note: The matlab code transforms an even-window size into an odd number by subtracting by one.
     # So for simplicity I already define the window size as an odd number
-    window_size = 99
     pxx0 = []
-    lcolours = ['#1F5E43', '#31C522', '#2242C5']
     for i in range(len(pz0)):
         pxx0.append(matlab_smooth(pz0[i, :], window_size))
     pxx0 = np.asarray(pxx0)
     pxx20 = np.mean(pxx0, axis=0)
     pxx20sig = np.std(pxx0, axis=0)
 
-    fxx_plt_idx = np.where((fx0 > 20) & (fx0 < 80))
+    fxx_plt_idx = np.where((fx0 > filter[0]) & (fx0 < filter[1]))
     z1 = pxx20[fxx_plt_idx]
     z2 = pxx20sig[fxx_plt_idx]
     b2 = np.argmax(z1)
@@ -131,49 +156,43 @@ def interareal_plt(area, px20, px2, fx2):
     barrasgamma[0, 1] = z2[b2]
 
     ## Analysis for model with stimulus
-    pz = np.squeeze(np.transpose(px2[:, area, :]))
-    fx = np.transpose(fx2[:, area, 1])
+    pz = np.squeeze(np.transpose(px[:, area_idx, :]))
+    fx = np.transpose(fx2[:, area_idx, 1])
     pxx = []
     for i in range(len(pz)):
         pxx.append(matlab_smooth(pz[i, :], window_size))
     pxx = np.asarray(pxx)
     pxx2 = np.mean(pxx, axis=0)
     pxx2sig = np.std(pxx, axis=0)
-    fxx_plt_idx = np.where((fx > 20) & (fx < 80))
+    fxx_plt_idx = np.where((fx > filter[0]) & (fx < filter[1]))
     z1 = pxx2[fxx_plt_idx]
     z2 = pxx2sig[fxx_plt_idx]
     b2 = np.argmax(z1)
     barrasgamma[1, 0] = z1[b2]
     barrasgamma[1, 1] = z2[b2]
 
-    # Plot results for V4 L2/3
+    # Plot results
     fig, ax = plt.subplots(1)
-    resbin2 = 20
-    plt_filled_std(ax, fx0[1:-1:resbin2], pxx20[1:-1:resbin2], pxx20sig[1:-1:resbin2], lcolours[0], 'rest')
-    plt_filled_std(ax, fx[1:-1:resbin2], pxx2[1:-1:resbin2], pxx2sig[1:-1:resbin2], lcolours[1], 'stimulus')
-    plt.xlim([20, 80])
-    plt.ylim([0, .006])
+    plt_filled_std(ax, fx0[1:-1:resbin], pxx20[1:-1:resbin], pxx20sig[1:-1:resbin], lcolours[0], 'rest')
+    plt_filled_std(ax, fx[1:-1:resbin], pxx2[1:-1:resbin], pxx2sig[1:-1:resbin], lcolours[1], 'stimulus')
+    plt.xlim(xlim)
+    plt.ylim(ylim)
     plt.xlabel('Frequency(Hz)')
     plt.ylabel('Power (resp. rest)')
     plt.legend()
-    plt.savefig('interareal/V4_l23.png')
+    plt.savefig('interareal/%s_%s.png' %(area, layer))
 
+
+def interareal_plt(areas, px20, px2, px50, px5, fx2):
+    '''
+
+    '''
+
+    # Plot the results only for V4.
     filter = [20, 80]
-    def plot_plot(filter):
+    lcolours = ['#1F5E43', '#31C522', '#2242C5']
+    plot_powerspectrum(filter, areas[1], 'l23', px20, px2, fx2, lcolours)
+    plot_powerspectrum(filter, areas[1], 'l56', px50, px5, fx2, lcolours)
 
-
-        return fx, pxx, pxx0, pxxsig, pxx0sig, z1, z2
-
-    # Plot results for V4 L5/6
-    # fig, ax = plt.subplots(1)
-    # resbin5 = 10
-    # plt_filled_std(ax, fx[1:-1:resbin5], pxx20[1:-1:resbin5], pxx20sig[1:-1:resbin5], lcolours[0], 'rest')
-    # plt_filled_std(ax, fx[1:-1:resbin5], pxx2[1:-1:resbin5], pxx2sig[1:-1:resbin5], lcolours[1], 'stimulus')
-    # plt.xlim([5, 20])
-    # plt.ylim([0, .025])
-    # plt.xlabel('Frequency(Hz)')
-    # plt.ylabel('Power (resp. rest)')
-    # plt.legend()
-    # plt.show()
 
 

--- a/Python/interlaminar.py
+++ b/Python/interlaminar.py
@@ -7,7 +7,7 @@ import matplotlib.pylab as plt
 from neurodsp import spectral
 
 from calculate_rate import calculate_rate
-from helper_functions import calculate_periodogram, compress_data
+from helper_functions import calculate_periodogram, compress_data, find_peak_frequency
 
 
 def interlaminar_simulation(analysis, t, dt, tstop, J, tau, sig, Iext, Ibgk, noise, Nareas):
@@ -20,28 +20,6 @@ def interlaminar_simulation(analysis, t, dt, tstop, J, tau, sig, Iext, Ibgk, noi
 
 
 
-def find_peak_frequency(fxx,pxx, min_freq):
-    # find the frequency of the oscillations
-    z = np.where(fxx > min_freq)
-    pxx_freq = pxx[z]
-    fxx_freq = fxx[z]
-
-    # Locate peaks in the spectrum
-    loc = signal.find_peaks(pxx_freq)[0]
-    pks = pxx_freq[loc]
-    z = len(loc)
-    # if there is at least one peak
-    if z > 1:
-        # find index of the highest peak
-        z3 = np.argmax(pks)
-        # find location in Hz of the higest peak
-        frequency = fxx_freq[loc[z3]]
-        # power of the peak in the spectrum
-        amplitude = pxx_freq[loc[z3]]
-    else:
-        frequency = 0
-        amplitude = 0
-    return frequency
 
 def my_pretransformations(x, window, noverlap, fs):
 
@@ -65,7 +43,7 @@ def interlaminar_activity_analysis(rate, transient, dt, t, min_freq5):
     x_5 = rate[2, int(round((transient + dt)/dt)) - 1:, 0]
 
     pxx, fxx = calculate_periodogram(x_5, transient, dt)
-    f_peakalpha = find_peak_frequency(fxx, pxx, min_freq5)
+    f_peakalpha, _, _, _ = find_peak_frequency(fxx, pxx, min_freq5)
     print('    Average peak frequency on the alpha range: %.02f Hz' %f_peakalpha)
 
     # band-pass filter L5 activity
@@ -127,7 +105,7 @@ def interlaminar_analysis_periodeogram(rate, segment2, transient, dt, min_freq2,
     # TODO: still in construction
     # calculate the spectogram for L2/3 and average the results over the segments
     pxx2, fxx2 = calculate_periodogram(rate[0, :, 0], transient, dt)
-    f_peakgamma = find_peak_frequency(fxx2, pxx2, min_freq2)
+    f_peakgamma, _, _, _ = find_peak_frequency(fxx2, pxx2, min_freq2)
     print('    Average peak frequency on the gamma range: %.02f Hz' %f_peakgamma)
     timewindow = 7/f_peakgamma
     window_len = int(round(timewindow/dt))
@@ -273,7 +251,6 @@ def plot_spectrogram(ff, tt, Sxx):
 
 
 def calculate_interlaminar_power_spectrum(rate, dt, transient, Nbin):
-
     # Calculate the rate for the passed connectivity
     pxx_l23, fxx_l23 = calculate_periodogram(rate[0, :, 0], transient, dt)
     pxx_l56, fxx_l56 = calculate_periodogram(rate[2, :, 0], transient, dt)

--- a/Python/intralaminar.py
+++ b/Python/intralaminar.py
@@ -5,24 +5,7 @@ from scipy import signal
 import matplotlib.pylab as plt
 
 from calculate_rate import calculate_rate
-from helper_functions import calculate_periodogram, compress_data
-
-
-def matlab_smooth(data, window_size):
-    # assumes the data is one dimensional
-    n = data.shape[0]
-    c = signal.lfilter(np.ones(window_size)/window_size, 1, data)
-    idx_begin = range(0, window_size - 2)
-    cbegin = data[idx_begin].cumsum()
-    # select every second elemeent and divide by their index
-    cbegin = cbegin[0::2] / range(1, window_size - 1, 2)
-    # select the list backwards
-    idx_end = range(n-1, n-window_size + 1, -1)
-    cend = data[idx_end].cumsum()
-    # select every other element until the end backwards
-    cend = cend[-1::-2] / (range(window_size - 2, 0, -2))
-    c = np.concatenate([cbegin, c[window_size-1:], cend])
-    return c
+from helper_functions import calculate_periodogram, compress_data, plt_filled_std, matlab_smooth
 
 
 def intralaminar_analysis(simulation, Iexts, nruns, layer='L23', dt=2e-04, transient=5):
@@ -72,15 +55,6 @@ def intralaminar_analysis(simulation, Iexts, nruns, layer='L23', dt=2e-04, trans
     print('    Done Analysis!')
     return psd_dic
 
-
-def plt_filled_std(ax, fxx_plt, data_mean, data_std, color, label):
-    # calculate upper and lower bounds of the plot
-    cis = (data_mean - data_std, data_mean + data_std)
-    # plot filled area
-    ax.fill_between(fxx_plt, cis[0], cis[1], alpha=0.2, color=color)
-    # plot mean
-    ax.plot(fxx_plt, data_mean, color=color, linewidth=2, label=label)
-    ax.margins(x=0)
 
 
 def intralaminar_plt(psd_dic):


### PR DESCRIPTION
Analyse the simulations from two areas (V1 and V4) interareal simulation generated with NeuroMLlite.
The NeuroML defined model shows similar properties as that described on the Mejias paper.

To replicate the figures below you can run the following:

```
-interareal -analysis -stimulate_V1
-interareal -analysis -stimulate_V4
```

## V1 Stimulation
![V1_stimulation](https://user-images.githubusercontent.com/10345440/55277737-44707380-52fb-11e9-8ead-b1e36f4fa456.png)

## V4 Stimulation
![V4_Stimulation](https://user-images.githubusercontent.com/10345440/55277736-44707380-52fb-11e9-92a9-84cb209312fa.png)


> Note: The Mejias paper reapeates the simulation 30 times in order to analyse the difference between rest and stimulated areas. The results shown here were also generated using the same amount of repetitions. However, this is a time consuming process and the simulation of 30 repetions can take up to 30min. 

The committed code uses 10 repetitions, but this value can be easily changed [here](https://github.com/OpenSourceBrain/MejiasEtAl2016/blob/fef277dfbcf18443e16d3c5083168c745452cd6d/NeuroML2/GenerateNeuroMLlite.py#L710). 